### PR TITLE
UPSTREAM: security: selinux: allow per-file labeling for bpffs

### DIFF
--- a/security/selinux/hooks.c
+++ b/security/selinux/hooks.c
@@ -873,7 +873,8 @@ static int selinux_set_mnt_opts(struct super_block *sb,
 	    !strcmp(sb->s_type->name, "pstore") ||
 	    !strcmp(sb->s_type->name, "binder") ||
 	    !strcmp(sb->s_type->name, "cgroup") ||
-	    !strcmp(sb->s_type->name, "cgroup2"))
+	    !strcmp(sb->s_type->name, "cgroup2") ||
+	    !strcmp(sb->s_type->name, "bpf"))
 		sbsec->flags |= SE_SBGENFS;
 
 	if (!sbsec->behavior) {


### PR DESCRIPTION
Add support for genfscon per-file labeling of bpffs files. This allows for separate permissions for different pinned bpf objects, which may be completely unrelated to each other.

Signed-off-by: Connor O'Brien <connoro@google.com>
Signed-off-by: Steven Moreland <smoreland@google.com>
Acked-by: Stephen Smalley <sds@tycho.nsa.gov>
Signed-off-by: Paul Moore <paul@paul-moore.com>
(cherry picked from commit 4ca54d3d3022ce27170b50e4bdecc3a42f05dbdc) [which is v5.6-rc1-10-g4ca54d3d3022 and thus already included in 5.10] Bug: 200440527
Change-Id: I8234b9047f29981b8140bd81bb2ff070b3b0b843 (cherry picked from commit d52ac987ad2ae16ff313d7fb6185bc412cb221a4)